### PR TITLE
Compatibility fixes for some models of air conditioners

### DIFF
--- a/include/Appliance/AirConditioner/StatusData.h
+++ b/include/Appliance/AirConditioner/StatusData.h
@@ -84,7 +84,7 @@ class StatusData : public FrameData {
   void setMode(Mode mode);
 
   /* FAN SPEED */
-  FanMode getFanMode() const { return static_cast<FanMode>(this->m_getValue(3)); }
+  FanMode getFanMode() const;
   void setFanMode(FanMode mode) { this->m_setValue(3, mode); };
 
   /* SWING MODE */

--- a/include/Frame/FrameData.h
+++ b/include/Frame/FrameData.h
@@ -32,9 +32,7 @@ class FrameData {
   static uint8_t m_getID() { return FrameData::m_id++; }
   static uint8_t m_getRandom() { return random(256); }
   uint8_t m_calcCRC() const;
-  uint8_t m_getValue(uint8_t idx, uint8_t mask = 255, uint8_t shift = 0) const {
-    return (this->m_data[idx] >> shift) & mask;
-  }
+  uint8_t m_getValue(uint8_t idx, uint8_t mask = 255, uint8_t shift = 0) const;
   void m_setValue(uint8_t idx, uint8_t value, uint8_t mask = 255, uint8_t shift = 0) {
     this->m_data[idx] &= ~(mask << shift);
     this->m_data[idx] |= (value << shift);

--- a/src/Appliance/AirConditioner/StatusData.cpp
+++ b/src/Appliance/AirConditioner/StatusData.cpp
@@ -51,9 +51,9 @@ void StatusData::setMode(Mode mode) {
 FanMode StatusData::getFanMode() const {
   //some ACs return 30 for LOW and 50 for MEDIUM. Note though, in appMode, this device still uses 40/60
   uint8_t fanMode = this->m_getValue(3);
-  if ( fanMode == 30 ){
+  if (fanMode == 30) {
     fanMode = FAN_LOW;
-  } else if ( fanMode == 50 ){
+  } else if (fanMode == 50) {
     fanMode = FAN_MEDIUM;
   }
   return static_cast<FanMode>(fanMode); 

--- a/src/Appliance/AirConditioner/StatusData.cpp
+++ b/src/Appliance/AirConditioner/StatusData.cpp
@@ -48,6 +48,17 @@ void StatusData::setMode(Mode mode) {
   }
 }
 
+FanMode StatusData::getFanMode() const {
+  //some ACs return 30 for LOW and 50 for MEDIUM. Note though, in appMode, this device still uses 40/60
+  uint8_t fanMode = this->m_getValue(3);
+  if ( fanMode == 30 ){
+    fanMode = FAN_LOW;
+  } else if ( fanMode == 50 ){
+    fanMode = FAN_MEDIUM;
+  }
+  return static_cast<FanMode>(fanMode); 
+}
+
 Preset StatusData::getPreset() const {
   if (this->m_getEco())
     return Preset::PRESET_ECO;

--- a/src/Frame/FrameData.cpp
+++ b/src/Frame/FrameData.cpp
@@ -31,6 +31,14 @@ uint8_t FrameData::m_calcCRC() const {
   return crc;
 }
 
+uint8_t FrameData::m_getValue(uint8_t idx, uint8_t mask, uint8_t shift) const {
+  if ( idx < this->m_data.size() ){
+    return (this->m_data[idx] >> shift) & mask;
+  } else {
+    return 0;
+  }
+}
+
 void NetworkNotifyData::setIP(const IPAddress &ip) {
   this->m_data[3] = ip[3];
   this->m_data[4] = ip[2];

--- a/src/Frame/FrameData.cpp
+++ b/src/Frame/FrameData.cpp
@@ -32,11 +32,9 @@ uint8_t FrameData::m_calcCRC() const {
 }
 
 uint8_t FrameData::m_getValue(uint8_t idx, uint8_t mask, uint8_t shift) const {
-  if ( idx < this->m_data.size() ){
+  if (idx < this->m_data.size())
     return (this->m_data[idx] >> shift) & mask;
-  } else {
-    return 0;
-  }
+  return 0;
 }
 
 void NetworkNotifyData::setIP(const IPAddress &ip) {


### PR DESCRIPTION
These were the fixes needed to support my msabbu-12hrdn1 (I think about 5 years old Aurora), what I used with EU-OSK103 dongle so far.

The first commit resolves that the AC's status report is shorter than what the code expects, e.g.:
RX: AA 1E AC 00 00 00 00 00 00 03 C0 01 AA 66 7F 7F 00 00 00 00 00 66 5E 00 00 00 00 00 00 6D 33 
This is 19B long, so m_getFreezeProtection() overreads it, resulting MideUART thinking the AC is in freeze protection mode and denying control of the fan. 

The second one resolves that the AC reports 30/50 for LOW/MEDIUM, instead of 40/60. This was also reported here:
https://github.com/esphome/issues/issues/2528

I've tested it with esphome 2023.7.1