### PR TITLE
feat: add ESP-IDF framework support

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,7 @@
+version: "1.2.0"
+description: "Midea UART protocol library for ESP-IDF and Arduino"
+url: "https://github.com/dudanov/MideaUART"
+repository: "https://github.com/dudanov/MideaUART.git"
+dependencies:
+  idf:
+    version: ">=5.0"

--- a/include/Appliance/AirConditioner/AirConditioner.h
+++ b/include/Appliance/AirConditioner/AirConditioner.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Arduino.h>
+#include "Helpers/Platform.h"
 #include "Appliance/ApplianceBase.h"
 #include "Appliance/AirConditioner/Capabilities.h"
 #include "Appliance/AirConditioner/StatusData.h"

--- a/include/Appliance/AirConditioner/Capabilities.h
+++ b/include/Appliance/AirConditioner/Capabilities.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Arduino.h>
+#include "Helpers/Platform.h"
 #include <set>
 
 namespace dudanov {

--- a/include/Appliance/AirConditioner/StatusData.h
+++ b/include/Appliance/AirConditioner/StatusData.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Arduino.h>
+#include "Helpers/Platform.h"
 #include "Frame/FrameData.h"
 
 namespace dudanov {

--- a/include/Appliance/ApplianceBase.h
+++ b/include/Appliance/ApplianceBase.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <deque>
-#include <Arduino.h>
+#include "Helpers/Platform.h"
 #include "Frame/Frame.h"
 #include "Frame/FrameData.h"
 #include "Helpers/Timer.h"

--- a/include/Frame/Frame.h
+++ b/include/Frame/Frame.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Arduino.h>
+#include "Helpers/Platform.h"
 #include <vector>
 #include "Frame/FrameData.h"
 #include "Helpers/Helpers.h"

--- a/include/Frame/FrameData.h
+++ b/include/Frame/FrameData.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Arduino.h>
+#include "Helpers/Platform.h"
 #include <vector>
 
 class IPAddress;

--- a/include/Helpers/Helpers.h
+++ b/include/Helpers/Helpers.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Arduino.h>
+#include "Helpers/Platform.h"
 #include <initializer_list>
 
 namespace dudanov {

--- a/include/Helpers/Log.h
+++ b/include/Helpers/Log.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Arduino.h>
+#include "Helpers/Platform.h"
 
 namespace dudanov {
 
@@ -17,7 +17,9 @@ namespace dudanov {
 #endif
 
 void sv_log_printf_(int level, const char *tag, int line, const char *format, ...);
+#ifdef ARDUINO
 void sv_log_printf_(int level, const char *tag, int line, const __FlashStringHelper *format, ...);
+#endif
 
 #if LOG_LEVEL >= LOG_LEVEL_VERY_VERBOSE
 #define sv_log_vv(tag, format, ...) \

--- a/include/Helpers/Logger.h
+++ b/include/Helpers/Logger.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Arduino.h>
+#include "Helpers/Platform.h"
 #include <cstdarg>
 #include <functional>
 

--- a/include/Helpers/Platform.h
+++ b/include/Helpers/Platform.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#else
+// ESP-IDF compatibility layer
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <functional>
+
+#include "esp_timer.h"
+#include "esp_random.h"
+
+// millis() replacement
+inline unsigned long millis() {
+  return (unsigned long)(esp_timer_get_time() / 1000ULL);
+}
+
+// random() replacement
+inline long random(long max) {
+  return esp_random() % max;
+}
+
+inline long random(long min, long max) {
+  return min + (esp_random() % (max - min));
+}
+
+// String replacement - use std::string
+using String = std::string;
+
+// F() macro - no-op on ESP-IDF (no flash strings needed)
+#define F(x) x
+
+// __FlashStringHelper - just const char* on ESP-IDF
+using __FlashStringHelper = const char;
+
+// Stream interface for ESP-IDF
+class Stream {
+ public:
+  virtual ~Stream() = default;
+  virtual int available() = 0;
+  virtual int read() = 0;
+  virtual int peek() = 0;
+  virtual size_t write(uint8_t data) = 0;
+  virtual size_t write(const uint8_t *data, size_t size) = 0;
+  virtual void flush() = 0;
+};
+
+// IPAddress for ESP-IDF
+class IPAddress {
+ public:
+  IPAddress() : addr_{0, 0, 0, 0} {}
+  IPAddress(uint8_t a, uint8_t b, uint8_t c, uint8_t d) : addr_{a, b, c, d} {}
+  uint8_t operator[](int index) const { return addr_[index]; }
+ private:
+  uint8_t addr_[4];
+};
+
+#endif  // ARDUINO

--- a/include/Helpers/Platform.h
+++ b/include/Helpers/Platform.h
@@ -2,6 +2,7 @@
 
 #ifdef ARDUINO
 #include <Arduino.h>
+#include <IPAddress.h>
 #else
 // ESP-IDF compatibility layer
 #include <cstdint>
@@ -59,3 +60,19 @@ class IPAddress {
 };
 
 #endif  // ARDUINO
+
+// WiFi availability detection
+#ifdef ARDUINO_ARCH_ESP8266
+  // ESP8266 always has WiFi
+  #define HAS_WIFI 1
+#elif defined(ESP32)
+  // ESP32 family: check chip capabilities
+  #include "soc/soc_caps.h"
+  #if SOC_WIFI_SUPPORTED
+    #define HAS_WIFI 1
+  #else
+    #define HAS_WIFI 0
+  #endif
+#else
+  #define HAS_WIFI 0
+#endif

--- a/include/Helpers/Platform.h
+++ b/include/Helpers/Platform.h
@@ -65,7 +65,13 @@ class IPAddress {
 #ifdef ARDUINO_ARCH_ESP8266
   // ESP8266 always has WiFi
   #define HAS_WIFI 1
-#elif defined(ESP32)
+#elif __has_include("soc/soc_caps.h")
+  #include "soc/soc_caps.h"
+  #ifdef SOC_WIFI_SUPPORTED
+    #define HAS_WIFI 1
+  #else
+    #define HAS_WIFI 0
+  #endif
   // ESP32 family: check chip capabilities
   #include "soc/soc_caps.h"
   #if SOC_WIFI_SUPPORTED

--- a/include/Helpers/Platform.h
+++ b/include/Helpers/Platform.h
@@ -65,16 +65,10 @@ class IPAddress {
 #ifdef ARDUINO_ARCH_ESP8266
   // ESP8266 always has WiFi
   #define HAS_WIFI 1
+// ESP32 family: check chip capabilities
 #elif __has_include("soc/soc_caps.h")
   #include "soc/soc_caps.h"
   #ifdef SOC_WIFI_SUPPORTED
-    #define HAS_WIFI 1
-  #else
-    #define HAS_WIFI 0
-  #endif
-  // ESP32 family: check chip capabilities
-  #include "soc/soc_caps.h"
-  #if SOC_WIFI_SUPPORTED
     #define HAS_WIFI 1
   #else
     #define HAS_WIFI 0

--- a/library.json
+++ b/library.json
@@ -19,6 +19,6 @@
   "license": "MIT",
   "dependencies": {
   },
-  "frameworks": "arduino",
+  "frameworks": ["arduino", "espidf"],
   "platforms": ["espressif8266", "espressif32"]
 }

--- a/src/Appliance/ApplianceBase.cpp
+++ b/src/Appliance/ApplianceBase.cpp
@@ -1,9 +1,18 @@
 #include "Appliance/ApplianceBase.h"
 #include "Helpers/Log.h"
-#ifdef ARDUINO_ARCH_ESP32
-#include <WiFi.h>
+
+#ifdef ARDUINO
+  #ifdef ARDUINO_ARCH_ESP32
+    #include <WiFi.h>
+  #else
+    #include <ESP8266WiFi.h>
+  #endif
+  #define HAS_WIFI 1
 #else
-#include <ESP8266WiFi.h>
+  // ESP-IDF
+  #include "esp_wifi.h"
+  #include "esp_netif.h"
+  #define HAS_WIFI 1
 #endif
 
 namespace dudanov {
@@ -108,6 +117,7 @@ void ApplianceBase::m_handler(const Frame &frame) {
   this->m_onRequest(frame);
 }
 
+#ifdef ARDUINO
 static uint8_t getSignalStrength() {
   const int32_t dbm = WiFi.RSSI();
   if (dbm > -63)
@@ -119,11 +129,51 @@ static uint8_t getSignalStrength() {
   return 1;
 }
 
+static bool isWifiConnected() {
+  return WiFi.isConnected();
+}
+
+static IPAddress getLocalIP() {
+  return WiFi.localIP();
+}
+#else
+// ESP-IDF implementations
+static uint8_t getSignalStrength() {
+  wifi_ap_record_t ap_info;
+  if (esp_wifi_sta_get_ap_info(&ap_info) == ESP_OK) {
+    int32_t dbm = ap_info.rssi;
+    if (dbm > -63) return 4;
+    if (dbm > -75) return 3;
+    if (dbm > -88) return 2;
+  }
+  return 1;
+}
+
+static bool isWifiConnected() {
+  wifi_ap_record_t ap_info;
+  return esp_wifi_sta_get_ap_info(&ap_info) == ESP_OK;
+}
+
+static IPAddress getLocalIP() {
+  esp_netif_ip_info_t ip_info;
+  esp_netif_t *netif = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+  if (netif && esp_netif_get_ip_info(netif, &ip_info) == ESP_OK) {
+    return IPAddress(
+      ip_info.ip.addr & 0xFF,
+      (ip_info.ip.addr >> 8) & 0xFF,
+      (ip_info.ip.addr >> 16) & 0xFF,
+      (ip_info.ip.addr >> 24) & 0xFF
+    );
+  }
+  return IPAddress();
+}
+#endif
+
 void ApplianceBase::m_sendNetworkNotify(FrameType msgType) {
   NetworkNotifyData notify{};
-  notify.setConnected(WiFi.isConnected());
+  notify.setConnected(isWifiConnected());
   notify.setSignalStrength(getSignalStrength());
-  notify.setIP(WiFi.localIP());
+  notify.setIP(getLocalIP());
   notify.appendCRC();
   if (msgType == NETWORK_NOTIFY) {
     LOG_D(TAG, "Enqueuing a DEVICE_NETWORK(0x0D) notification...");

--- a/src/Appliance/ApplianceBase.cpp
+++ b/src/Appliance/ApplianceBase.cpp
@@ -7,12 +7,11 @@
   #else
     #include <ESP8266WiFi.h>
   #endif
-  #define HAS_WIFI 1
 #else
-  // ESP-IDF
-  #include "esp_wifi.h"
-  #include "esp_netif.h"
-  #define HAS_WIFI 1
+  #if HAS_WIFI
+    #include "esp_wifi.h"
+    #include "esp_netif.h"
+  #endif
 #endif
 
 namespace dudanov {
@@ -117,6 +116,8 @@ void ApplianceBase::m_handler(const Frame &frame) {
   this->m_onRequest(frame);
 }
 
+#if HAS_WIFI
+
 #ifdef ARDUINO
 static uint8_t getSignalStrength() {
   const int32_t dbm = WiFi.RSSI();
@@ -167,7 +168,15 @@ static IPAddress getLocalIP() {
   }
   return IPAddress();
 }
-#endif
+#endif  // ARDUINO
+
+#else  // !HAS_WIFI
+
+static uint8_t getSignalStrength() { return 0; }
+static bool isWifiConnected() { return false; }
+static IPAddress getLocalIP() { return IPAddress(); }
+
+#endif  // HAS_WIFI
 
 void ApplianceBase::m_sendNetworkNotify(FrameType msgType) {
   NetworkNotifyData notify{};

--- a/src/Frame/FrameData.cpp
+++ b/src/Frame/FrameData.cpp
@@ -1,5 +1,13 @@
 #include "Frame/FrameData.h"
-#include <IPAddress.h>
+#include "Helpers/Platform.h"
+
+#ifndef PROGMEM
+#define PROGMEM
+#endif
+
+#ifndef pgm_read_byte
+#define pgm_read_byte(addr) (*(const uint8_t *)(addr))
+#endif
 
 namespace dudanov {
 namespace midea {

--- a/src/Helpers/Log.cpp
+++ b/src/Helpers/Log.cpp
@@ -16,6 +16,7 @@ void sv_log_printf_(int level, const char *tag, int line, const char *format, ..
   va_end(arg);
 }
 
+#ifdef ARDUINO
 void sv_log_printf_(int level, const char *tag, int line, const __FlashStringHelper *format, ...) {
   if (logger_ == nullptr)
     return;
@@ -24,5 +25,6 @@ void sv_log_printf_(int level, const char *tag, int line, const __FlashStringHel
   logger_(level, tag, line, format, arg);
   va_end(arg);
 }
+#endif
 
 }  // namespace dudanov

--- a/src/Helpers/Timer.cpp
+++ b/src/Helpers/Timer.cpp
@@ -1,4 +1,4 @@
-#include <Arduino.h>
+#include "Helpers/Platform.h"
 #include "Helpers/Timer.h"
 
 namespace dudanov {


### PR DESCRIPTION
Add Platform.h abstraction layer enabling ESP-IDF framework alongside Arduino:
- `millis()`, `random()`, `Stream`, `IPAddress` implementations for ESP-IDF
- ESP-IDF WiFi functions using `esp_wifi.h` and `esp_netif.h`
- `PROGMEM`/`pgm_read_byte` fallback macros for ESP-IDF
- Conditional `__FlashStringHelper` in Log.h

Tested on ESP32-C3.