### PR TITLE
Don't poll power usage when not configured or the unit does not support it

### DIFF
--- a/include/Appliance/AirConditioner/AirConditioner.h
+++ b/include/Appliance/AirConditioner/AirConditioner.h
@@ -38,6 +38,7 @@ class AirConditioner : public ApplianceBase {
   Preset getPreset() const { return this->m_preset; }
   const Capabilities &getCapabilities() const { return this->m_capabilities; }
   void displayToggle() { this->m_displayToggle(); }
+  void setPowerUsagePolling(bool enable) { this->m_powerUsagePolling = enable; }
  protected:
   void m_getPowerUsage();
   void m_getCapabilities();
@@ -59,6 +60,7 @@ class AirConditioner : public ApplianceBase {
   Preset m_lastPreset{Preset::PRESET_NONE};
   StatusData m_status{};
   bool m_sendControl{};
+  bool m_powerUsagePolling{true};
 };
 
 }  // namespace ac

--- a/src/Appliance/AirConditioner/AirConditioner.cpp
+++ b/src/Appliance/AirConditioner/AirConditioner.cpp
@@ -127,6 +127,10 @@ void AirConditioner::setPowerState(bool state) {
 }
 
 void AirConditioner::m_getPowerUsage() {
+  if (!this->m_powerUsagePolling)
+    return;
+  if (this->m_autoconfStatus == AUTOCONF_OK && !this->m_capabilities.powerCal())
+    return;
   QueryPowerData data{};
   LOG_D(TAG, "Enqueuing a GET_POWERUSAGE(0x41) request...");
   this->m_queueRequest(FrameType::DEVICE_QUERY, std::move(data),


### PR DESCRIPTION
This fixes #34 for me.

The default is to keep polling power usage, unless autoconf is configured and it is determined the unit does not support power polling.