### PR TITLE
Allow changing fan speed on other cooling modes

### DIFF
--- a/src/Appliance/AirConditioner/AirConditioner.cpp
+++ b/src/Appliance/AirConditioner/AirConditioner.cpp
@@ -60,12 +60,7 @@ void AirConditioner::control(const Control &control) {
     preset = control.preset.value();
   }
   if (mode != Mode::MODE_OFF) {
-    if (mode == Mode::MODE_AUTO || preset != Preset::PRESET_NONE) {
-      if (this->m_fanMode != FanMode::FAN_AUTO) {
-        hasUpdate = true;
-        status.setFanMode(FanMode::FAN_AUTO);
-      }
-    } else if (control.fanMode.hasUpdate(this->m_fanMode)) {
+    if (control.fanMode.hasUpdate(this->m_fanMode)) {
       hasUpdate = true;
       status.setFanMode(control.fanMode.value());
     }


### PR DESCRIPTION
Currently if the cooling mode is set to anything other than fan, it automatically forces the auto fan speed.
I've removed that code which results in being able to properly change the fan speed.

I'm guessing it was meant to prevent changing the fan speed in the dry mode, but even in my testing it functions as normal without the additional check that caused this issue.

Closes #17 #21 #25