### PR TITLE
Add support for libretiny

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        env: [esp8266-arduino, esp32-arduino, esp32-idf]
+        env: [esp8266-arduino, esp32-arduino, esp32-idf, libretiny]
 
     steps:
       - uses: actions/checkout@v6

--- a/library.json
+++ b/library.json
@@ -20,5 +20,5 @@
   "dependencies": {
   },
   "frameworks": ["arduino", "espidf"],
-  "platforms": ["espressif8266", "espressif32"]
+  "platforms": ["espressif8266", "espressif32", "libretiny"]
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,7 @@ default_envs =
 	esp8266-arduino
 	esp32-arduino
 	esp32-idf
+	libretiny
 	native
 
 [env]
@@ -50,6 +51,12 @@ platform = espressif32
 framework = espidf
 board = esp32dev
 build_src_filter = +<../test/entry_idf.cpp>
+
+[env:libretiny]
+platform = libretiny
+framework = arduino
+board = generic-bk7231n-qfn32
+build_src_filter = +<../test/entry_arduino.cpp>
 
 [env:native]
 platform = native

--- a/src/Appliance/ApplianceBase.cpp
+++ b/src/Appliance/ApplianceBase.cpp
@@ -2,10 +2,10 @@
 #include "Helpers/Log.h"
 
 #ifdef ARDUINO
-  #ifdef ARDUINO_ARCH_ESP32
-    #include <WiFi.h>
-  #else
+  #ifdef ARDUINO_ARCH_ESP8266
     #include <ESP8266WiFi.h>
+  #else
+    #include <WiFi.h>
   #endif
 #else
   #if HAS_WIFI


### PR DESCRIPTION
This PR adds support for libretiny, which closes #10

The only required change in the source code was to only include the ESP8266 wifi header if the target is really a ESP8266.